### PR TITLE
123 add qt and rpm2cpio

### DIFF
--- a/packages/system.yaml
+++ b/packages/system.yaml
@@ -162,6 +162,16 @@ packages:
   - debian: procps
     rhel: procps-ng
 
+  # Tools for unpacking and manipulating RPM package files.
+  - ubuntu: rpm2cpio cpio
+    rhel: cpio
+    debian: rpm2cpio cpio
+
+  # Libraries for QT6 GUI applications, including platform plugins.
+  - ubuntu: libxcb-cursor0 libxcb1 qt6-qpa-plugins
+    rhel: libxcb libxcb-cursor qt6-qtbase-gui
+    debian: libxcb-cursor0 libxcb1 qt6-qpa-plugins
+
   # ====================================
   # X11 and Display Server Packages
   # ====================================

--- a/packages/system.yaml
+++ b/packages/system.yaml
@@ -168,9 +168,9 @@ packages:
     debian: rpm2cpio cpio
 
   # Libraries for QT6 GUI applications, including platform plugins.
-  - ubuntu: libxcb-cursor0 libxcb1 qt6-qpa-plugins
-    rhel: libxcb libxcb-cursor qt6-qtbase-gui
-    debian: libxcb-cursor0 libxcb1 qt6-qpa-plugins
+  - ubuntu: qt6-qpa-plugins
+    rhel: libatomic xcb-util-wm xcb-util-cursor qt5-qtbase-gui
+    debian: libxcb-cursor0 qt6-qpa-plugins
 
   # ====================================
   # X11 and Display Server Packages


### PR DESCRIPTION
### Before requesting review, I have done the following:

- [ ] Code Formatting
- [ ] Linting
- [ ] Added Tests (if any)
- [ ] Updated Documentation (if any)
- [ ] Resolved any Merge Conflicts

These additional packages are mainly to get the Autodesk Flow app to work but should lay a good foundation for any app needing QT.
I tested these packages across the distros to confirm it works.

`xcb-util-wm` is technically already implemented under the `Nuke Dependencies` section.
I can remove this duplicate if that's best practice, but left it in case someone removes it from the Nuke Dependencies section then all QT apps on rhel will more than likely have issues.